### PR TITLE
Fix no icon error on ubuntu GNOME dash; fixes #7

### DIFF
--- a/generate_desktop_files
+++ b/generate_desktop_files
@@ -1,0 +1,39 @@
+#!/usr/bin/python3
+
+DOMAIN = "theme-manager"
+PATH = "/usr/share/locale"
+
+import os
+import gettext
+import additionalfiles
+
+os.environ['LANGUAGE'] = "en_US.UTF-8"
+gettext.install(DOMAIN, PATH)
+
+prefix = "[Desktop Entry]\n"
+
+suffix = """Exec=theme-manager
+Icon=theme-manager
+Terminal=false
+Type=Application
+Encoding=UTF-8
+Categories=Application;Utility;
+StartupNotify=true
+NotShowIn=KDE;
+"""
+
+additionalfiles.generate(DOMAIN, PATH, "usr/share/applications/theme-manager.desktop", prefix, _("Theme Manager"), _("Very simple Python3-based GUI application to randomly choose and set different theme variants on linux."), suffix)
+
+prefix = "[Desktop Entry]\n"
+
+suffix = """Exec=theme-manager
+Icon=theme-manager
+Terminal=false
+Type=Application
+Encoding=UTF-8
+Categories=Application;Utility;
+X-KDE-StartupNotify=true
+OnlyShowIn=KDE;
+"""
+
+additionalfiles.generate(DOMAIN, PATH, "usr/share/applications/kde4/theme-manager.desktop", prefix, _("Theme Manager"), _("Very simple Python3-based GUI application to randomly choose and set different theme variants on linux."), suffix, genericName=_("Theme Manager"))

--- a/usr/share/applications/kde4/theme-manager.desktop
+++ b/usr/share/applications/kde4/theme-manager.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Theme Manager
-Comment=
+Comment=Very simple Python3-based GUI application to randomly choose and set different theme variants on linux.
 GenericName=Theme Manager
 Exec=theme-manager
 Icon=theme-manager
@@ -8,5 +8,5 @@ Terminal=false
 Type=Application
 Encoding=UTF-8
 Categories=Application;Utility;
-X-KDE-StartupNotify=false
+X-KDE-StartupNotify=true
 OnlyShowIn=KDE;

--- a/usr/share/applications/theme-manager.desktop
+++ b/usr/share/applications/theme-manager.desktop
@@ -1,11 +1,11 @@
 [Desktop Entry]
 Name=Theme Manager
-Comment=
+Comment=Very simple Python3-based GUI application to randomly choose and set different theme variants on linux.
 Exec=theme-manager
 Icon=theme-manager
 Terminal=false
 Type=Application
 Encoding=UTF-8
 Categories=Application;Utility;
-StartupNotify=false
+StartupNotify=true
 NotShowIn=KDE;

--- a/usr/share/theme-manager/theme-manager.ui
+++ b/usr/share/theme-manager/theme-manager.ui
@@ -25,6 +25,7 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
   <requires lib="gtk+" version="3.24"/>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name theme-manager -->
+  <!-- interface-description Very simple Python3-based GUI application to randomly choose and set different theme variants on linux. -->
   <!-- interface-copyright 2021 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> -->
   <!-- interface-authors Himadri Sekhar Basu <hsb10@iitbbs.ac.in> -->
   <object class="GtkMenu" id="main_menu">
@@ -37,6 +38,7 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
     <property name="window-position">center</property>
     <property name="default-width">600</property>
     <property name="default-height">400</property>
+    <property name="icon-name">theme-manager</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>


### PR DESCRIPTION
- add generate_desktop_files
- update desktop files using generate_desktop_files
- Add theme-manager icon to ui file