### PR TITLE
Accomodate both Mint-Y and Yaru like themes

### DIFF
--- a/data/ui/theme-manager.ui
+++ b/data/ui/theme-manager.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 
 
-Copyright (C) 2021 Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
+Copyright (C) 2021-2022 Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
 
 This file is part of theme-manager.
 
@@ -26,7 +26,7 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
   <!-- interface-license-type gplv3 -->
   <!-- interface-name theme-manager -->
   <!-- interface-description Very simple Python3-based GUI application to randomly choose and set different theme variants on linux. -->
-  <!-- interface-copyright 2021 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> -->
+  <!-- interface-copyright 2021-2022 Himadri Sekhar Basu <hsb10@iitbbs.ac.in> -->
   <!-- interface-authors Himadri Sekhar Basu <hsb10@iitbbs.ac.in> -->
   <object class="GtkAdjustment" id="HH">
     <property name="upper">47</property>
@@ -71,6 +71,7 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
               <object class="GtkBox" id="system_theme">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
+                <property name="valign">center</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkBox" id="theme_colors">
@@ -78,7 +79,6 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
                     <property name="can-focus">False</property>
                     <property name="margin-start">5</property>
                     <property name="margin-end">5</property>
-                    <property name="margin-top">5</property>
                     <property name="margin-bottom">5</property>
                     <property name="spacing">10</property>
                     <child>
@@ -92,7 +92,7 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
                         <property name="margin-end">10</property>
                         <property name="margin-top">10</property>
                         <property name="margin-bottom">10</property>
-                        <property name="label" translatable="yes">Color Variants:</property>
+                        <property name="label" translatable="yes">Colour Variants:</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -126,15 +126,15 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
                   <object class="GtkBox" id="theme_names">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-top">5</property>
+                    <property name="valign">center</property>
                     <property name="margin-bottom">5</property>
                     <property name="orientation">vertical</property>
-                    <property name="spacing">10</property>
                     <property name="homogeneous">True</property>
                     <child>
                       <object class="GtkFrame">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="valign">center</property>
                         <property name="margin-start">5</property>
                         <property name="margin-end">5</property>
                         <property name="label-xalign">0.009999999776482582</property>
@@ -197,6 +197,7 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
                       <object class="GtkFrame">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="valign">center</property>
                         <property name="margin-start">5</property>
                         <property name="margin-end">5</property>
                         <property name="label-xalign">0.009999999776482582</property>
@@ -259,6 +260,7 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
                       <object class="GtkFrame">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
+                        <property name="valign">center</property>
                         <property name="margin-start">5</property>
                         <property name="margin-end">5</property>
                         <property name="label-xalign">0.009999999776482582</property>
@@ -267,18 +269,37 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
                           <object class="GtkBox">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="margin-top">5</property>
-                            <property name="margin-bottom">5</property>
-                            <property name="spacing">10</property>
+                            <property name="orientation">vertical</property>
                             <child>
-                              <object class="GtkLabel">
+                              <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="valign">center</property>
-                                <property name="label" translatable="yes">Cursor Icon theme name:</property>
+                                <property name="spacing">10</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="valign">center</property>
+                                    <property name="label" translatable="yes">Change Cursor theme:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkSwitch" id="cursor_switch">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -287,13 +308,64 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkEntry" id="cursor_theme_name">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="tooltip-text" translatable="yes">Enter name of cursor theme to be used.</property>
-                                <property name="valign">center</property>
-                                <property name="hexpand">True</property>
-                                <property name="placeholder-text" translatable="yes">Enter available cursor theme name</property>
+                              <!-- n-columns=2 n-rows=2 -->
+                              <object class="GtkGrid" id="cursor_settings">
+                                <property name="can-focus">False</property>
+                                <property name="column-spacing">10</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <property name="label" translatable="yes">Cursor Icon theme name:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="cursor_theme_name">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Enter name of cursor theme to be used.</property>
+                                    <property name="valign">center</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="placeholder-text" translatable="yes">Enter available cursor theme name</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="valign">center</property>
+                                    <property name="label" translatable="yes">Cursor Colour Variants:</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkEntry" id="cursor_colour_variants">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="tooltip-text" translatable="yes">Enter available colour variants. </property>
+                                    <property name="valign">center</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="placeholder-text" translatable="yes">Enter available colour variants</property>
+                                  </object>
+                                  <packing>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -317,11 +389,182 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
                         <property name="position">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkFrame">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="valign">center</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
+                        <property name="label-xalign">0.009999999776482582</property>
+                        <property name="shadow-type">out</property>
+                        <child>
+                          <!-- n-columns=2 n-rows=3 -->
+                          <object class="GtkGrid">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-start">5</property>
+                            <property name="margin-end">5</property>
+                            <property name="margin-top">5</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="row-spacing">5</property>
+                            <property name="column-spacing">10</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <property name="label" translatable="yes">Dark Mode Suffix:</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="dark_mode_name">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="tooltip-text" translatable="yes">Suffix for dark mode is case sensitive. For example, Yaru uses suffix "-dark" to distinguish from light theme. In contrast, Mint uses "Dark".</property>
+                                <property name="hexpand">True</property>
+                                <property name="placeholder-text" translatable="yes">Enter suffix for dark mode.</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <property name="label" translatable="yes">Darker Mode Available:</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSwitch" id="darker_switch">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="tooltip-text" translatable="yes">Mint used to provide a theme mode with a mix of light and dark components called as "Darker". Sucharu provides the same with suffix "darker".</property>
+                                <property name="halign">start</property>
+                                <property name="valign">center</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="darker_mode_label">
+                                <property name="can-focus">False</property>
+                                <property name="halign">end</property>
+                                <property name="valign">center</property>
+                                <property name="label" translatable="yes">Darker Mode Suffix:</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="darker_mode_name">
+                                <property name="can-focus">True</property>
+                                <property name="tooltip-text" translatable="yes">Suffix for darker mode is case sensitive. For example, Mint used to provide a theme with a mix of light and dark components called as "Darker". Sucharu provides the same with suffix "darker".</property>
+                                <property name="hexpand">True</property>
+                                <property name="placeholder-text" translatable="yes">Enter suffix for darker mode.</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="label">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Dark Modes</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">5</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-end">5</property>
+                    <property name="margin-bottom">5</property>
+                    <property name="label-xalign">0.009999999776482582</property>
+                    <property name="shadow-type">out</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">5</property>
+                        <property name="margin-end">5</property>
+                        <property name="margin-top">5</property>
+                        <property name="margin-bottom">5</property>
+                        <property name="spacing">10</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <property name="label" translatable="yes">Theme Name Style:</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="theme_name_style_combo">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Theme Name</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>
@@ -542,6 +785,9 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
           </packing>
         </child>
         <child>
+          <placeholder/>
+        </child>
+        <child>
           <object class="GtkFrame">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -571,7 +817,7 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="pack-type">end</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -611,11 +857,8 @@ Author: Himadri Sekhar Basu <hsb10@iitbbs.ac.in>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="pack-type">end</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
-        </child>
-        <child>
-          <placeholder/>
         </child>
       </object>
     </child>

--- a/src/ThemeManager/DesktopTheme.py
+++ b/src/ThemeManager/DesktopTheme.py
@@ -25,6 +25,8 @@ import logging
 import os
 import subprocess
 
+from ThemeManager.common import TMBackend
+
 
 # logger
 module_logger = logging.getLogger('ThemeManager.DesktopTheme')
@@ -32,7 +34,8 @@ module_logger = logging.getLogger('ThemeManager.DesktopTheme')
 class desktop_theme():
 	
 	def __init__(self):
-			pass
+		self.manager = TMBackend()
+		pass
 	
 	def set_desktop_theme(self, state, nexttheme):
 		module_logger.info("Desktop session: %s", state['DE'])
@@ -48,13 +51,14 @@ class desktop_theme():
 			# Icon theme
 			os.system("gsettings set org.cinnamon.desktop.interface icon-theme %s" % nexttheme[6])
 			# Cursor theme
-			os.system("gsettings set org.cinnamon.desktop.interface cursor-theme %s" % nexttheme[7])
+			if self.manager.cursor_theme:
+				os.system("gsettings set org.cinnamon.desktop.interface cursor-theme %s" % nexttheme[7])
 			
 			# plank theme
 			try:
 				os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[3])
 			except:
-				module_logger.error("Either 'plank' is not installed or the plank theme is not present")
+				module_logger.error("Either 'plank' is not installed or the plank theme is not present.")
 		
 		elif (thisDE == "gnome" or thisDE == "ubuntu:gnome" or thisDE == "unity"):
 			# When the DE is gnome set
@@ -67,13 +71,14 @@ class desktop_theme():
 			# Icon theme
 			os.system("gsettings set org.gnome.desktop.interface icon-theme %s" % nexttheme[6])
 			# Cursor theme
-			os.system("gsettings set org.gnome.desktop.interface cursor-theme %s" % nexttheme[7])
+			if self.manager.cursor_theme:
+				os.system("gsettings set org.gnome.desktop.interface cursor-theme %s" % nexttheme[7])
 			
 			# plank theme
 			try:
 				os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[3])
 			except:
-				module_logger.error("Either 'plank' is not installed or the plank theme is not present")
+				module_logger.error("Either 'plank' is not installed or the plank theme is not present.")
 		
 		elif (thisDE == "mate"):
 			# When the DE is mate set
@@ -84,7 +89,8 @@ class desktop_theme():
 			# Icon theme
 			os.system("gsettings set org.mate.interface icon-theme %s" % nexttheme[6])
 			# Cursor theme
-			os.system("gsettings set org.mate.peripherals-mouse cursor-theme %s" % nexttheme[7])
+			if self.manager.cursor_theme:
+				os.system("gsettings set org.mate.peripherals-mouse cursor-theme %s" % nexttheme[7])
 			
 			# plank theme
 			try:

--- a/src/ThemeManager/gui.py
+++ b/src/ThemeManager/gui.py
@@ -91,19 +91,43 @@ class ThemeManagerWindow():
 		self.color_variants = self.builder.get_object("colour_variants")
 		self.systemtheme_variants = self.builder.get_object("system_theme_name")
 		self.icontheme_variants = self.builder.get_object("Icon_theme_name")
-		self.cursortheme_variants = self.builder.get_object("cursor_theme_name")
+		
+		self.cursor_theme_name = self.builder.get_object("cursor_theme_name")
+		self.cursor_colour_variants = self.builder.get_object("cursor_colour_variants")
+		self.cursor_settings = self.builder.get_object("cursor_settings")
+		
+		self.darkmode_name = self.builder.get_object("dark_mode_name")
+		self.darkermode_switch = self.builder.get_object("darker_switch")
+		self.darkermode_label = self.builder.get_object("darker_mode_label")
+		self.darkermode_name = self.builder.get_object("darker_mode_name")
 		self.user_interval_HH = self.builder.get_object("hour")
 		self.user_interval_MM = self.builder.get_object("minute")
 		self.user_interval_SS = self.builder.get_object("second")
 		
 		# Buttons
+		self.cursor_switch = self.builder.get_object("cursor_switch")
+		self.darkermode_switch = self.builder.get_object("darker_switch")
 		self.randomize_button = self.builder.get_object("randomize_theme_button")
 		self.save_button = self.builder.get_object("save_button")
+		
+		# Combo box
+		theme_style_store = Gtk.ListStore(str)
+		self.theme_styles = ["name-mode-color", "name-color-mode"]
+		for style in self.theme_styles:
+			theme_style_store.append([style])
+		self.theme_name_style_combo = self.builder.get_object("theme_name_style_combo")
+		renderer = Gtk.CellRendererText()
+		self.theme_name_style_combo.pack_start(renderer, True)
+		self.theme_name_style_combo.add_attribute(renderer, "text", 0)
+		self.theme_name_style_combo.set_model(theme_style_store)
 		
 		# Widget signals
 		self.randomize_button.connect("clicked", self.on_random_button)
 		self.save_button.connect("clicked", self.on_save_button)
 		# self.quit_button.connect("clicked", self.on_quit)
+		
+		#TODO: Show entries when cursor and darker switch is clicked
+		# self.cursor_switch.connect("notify::active", self.load_conf)
 		
 		# Menubar
 		accel_group = Gtk.AccelGroup()
@@ -157,10 +181,31 @@ class ThemeManagerWindow():
 		self.color_variants.set_text(str(self.manager.colorvariants))
 		self.systemtheme_variants.set_text(str(self.manager.systemthemename))
 		self.icontheme_variants.set_text(str(self.manager.iconthemename))
-		self.cursortheme_variants.set_text(str(self.manager.cursorthemename))
+		
+		self.cursor_switch.set_active(self.manager.cursor_theme)
+		self.cursor_theme_name.set_text(str(self.manager.cursorthemename))
+		self.cursor_colour_variants.set_text(str(self.manager.cursor_colorvariants))
+		if self.manager.cursor_theme:
+			self.cursor_settings.set_visible(True)
+		else:
+			self.cursor_settings.set_visible(False)
+		
+		self.darkmode_name.set_text(str(self.manager.darkmode_suffix))
+		self.darkermode_switch.set_active(self.manager.darkermode)
+		self.darkermode_name.set_text(str(self.manager.darkermode_suffix))
+		
+		self.theme_name_style_combo.set_active(self.manager.theme_name_style) # Select 1st category
+		
 		self.user_interval_HH.set_value(self.manager.theme_interval_HH)
 		self.user_interval_MM.set_value(self.manager.theme_interval_MM)
 		self.user_interval_SS.set_value(self.manager.theme_interval_SS)
+		
+		if self.manager.darkermode:
+			self.darkermode_label.set_visible(True)
+			self.darkermode_name.set_visible(True)
+		else:
+			self.darkermode_label.set_visible(False)
+			self.darkermode_name.set_visible(False)
 	
 	def on_quit(self, widget):
 		self.application.quit()
@@ -168,7 +213,7 @@ class ThemeManagerWindow():
 	def on_random_button(self, widget):
 		module_logger.info("User requested change using Randomize button.")
 		self.state = self.manager.get_state_info()
-		self.nexttheme = self.manager.prep_theme_variants(self.state)
+		self.nexttheme = self.manager.prep_theme_variants(self.state, self.theme_styles)
 		self.destop_manager.set_desktop_theme(self.state, self.nexttheme)
 		self.currenttheme = self.destop_manager.get_desktop_theme(self.state, self.manager.systemthemename, self.manager.colvariants)
 		self.current_status()
@@ -189,7 +234,13 @@ class ThemeManagerWindow():
 			'color-variants': self.color_variants.get_text(),
 			'system-theme-name': self.systemtheme_variants.get_text(),
 			'icon-theme-name': self.icontheme_variants.get_text(),
-			'cursor-theme-name': self.cursortheme_variants.get_text(),
+			'cursor-theme': self.cursor_switch.get_active(),
+			'cursor-theme-name': self.cursor_theme_name.get_text(),
+			'cursor-color-variants': self.cursor_colour_variants.get_text(),
+			'theme-style-name': self.theme_name_style_combo.get_active(),
+			'dark-mode-suffix': self.darkmode_name.get_text(),
+			'darker-mode': self.darkermode_switch.get_active(),
+			'darker-mode-suffix': self.darkermode_name.get_text(),
 			'theme-interval': user_interval
 		}
 		with open(CONFIG_FILE, 'w') as f:


### PR DESCRIPTION
- Add option to enter dark mode suffix
- Add option to use "Darker" mode
- Add option to enter darker mode suffix
- Add option to modify cursor theme, users might not want to change the cursor theme. Also many Yaru like themes might not provide colour variants for cursor.
- Add option to enter cursor theme name different from system and icon themes
- Add option to enter colour variants different from system and icon themes
- By default uses the colour variant of system and icon themes for cursor if the same variant is entered in the cursor colour variants entry
- Update copyright year to 2022