### PR TITLE
Fix no theme change error when auto-started

### DIFF
--- a/src/ThemeManager/common.py
+++ b/src/ThemeManager/common.py
@@ -73,6 +73,7 @@ __version__ = open(version_file, 'r').readlines()[0]
 CONFIG_DIR = os.path.expanduser('~/.config/theme-manager/')
 CONFIG_FILE = os.path.join(CONFIG_DIR+'config.cfg')
 UI_PATH = _path+"/ui/"
+theme_styles = ["name-mode-color", "name-color-mode"]
 
 # Used as a decorator to run things in the background
 def _async(func):

--- a/src/ThemeManager/gui.py
+++ b/src/ThemeManager/gui.py
@@ -34,7 +34,7 @@ warnings.filterwarnings("ignore")
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gio
 
-from ThemeManager.common import APP, CONFIG_FILE, LOCALE_DIR, UI_PATH, __version__, _async, TMBackend
+from ThemeManager.common import APP, CONFIG_FILE, LOCALE_DIR, UI_PATH, __version__, theme_styles, _async, TMBackend
 from ThemeManager.indicator import TMIndicator
 from ThemeManager.DesktopTheme import desktop_theme
 # from ThemeManager.LoginTheme import login_theme
@@ -112,7 +112,7 @@ class ThemeManagerWindow():
 		
 		# Combo box
 		theme_style_store = Gtk.ListStore(str)
-		self.theme_styles = ["name-mode-color", "name-color-mode"]
+		self.theme_styles = theme_styles
 		for style in self.theme_styles:
 			theme_style_store.append([style])
 		self.theme_name_style_combo = self.builder.get_object("theme_name_style_combo")

--- a/src/ThemeManager/indicator.py
+++ b/src/ThemeManager/indicator.py
@@ -33,7 +33,7 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 from ThemeManager.about_window import AboutWindow
-from ThemeManager.common import APP, LOCALE_DIR, LOGFILE, UI_PATH
+from ThemeManager.common import APP, LOCALE_DIR, LOGFILE, UI_PATH, theme_styles
 from ThemeManager.tm_daemon import TMState_monitor
 from ThemeManager.DesktopTheme import desktop_theme
 
@@ -60,6 +60,7 @@ class TMIndicator():
 		
 		self.destop_manager = desktop_theme()
 		self.daemon = TMState_monitor()
+		self.theme_styles = theme_styles
 		self.daemon.startdaemons()
 		
 		# create menu
@@ -100,7 +101,7 @@ class TMIndicator():
 	def next_theme(self, *args):
 		module_logger.info("User requested change using Next button from indicator.")
 		self.state = self.daemon.manager.get_state_info()
-		self.nexttheme = self.daemon.manager.prep_theme_variants(self.state)
+		self.nexttheme = self.daemon.manager.prep_theme_variants(self.state, self.theme_styles)
 		self.daemon.destop_manager.set_desktop_theme(self.state, self.nexttheme)
 	
 	def show_logs(self, widget):

--- a/src/ThemeManager/tm_daemon.py
+++ b/src/ThemeManager/tm_daemon.py
@@ -21,15 +21,13 @@
 #
 
 # import the necessary modules!
-from curses import wrapper
 import gettext
 import locale
 import logging
 
-from threading import Thread
 from time import sleep
 
-from ThemeManager.common import APP, LOCALE_DIR, _async, TMBackend
+from ThemeManager.common import APP, LOCALE_DIR, theme_styles, _async, TMBackend
 from ThemeManager.DesktopTheme import desktop_theme
 
 
@@ -46,6 +44,7 @@ class TMState_monitor():
 	def __init__(self):
 		module_logger.debug("Initiaing Theme Manager daemon.")
 		self.manager = TMBackend()
+		self.theme_styles = theme_styles
 		self.destop_manager = desktop_theme()
 		self.last_state = 'Unknown'
 	
@@ -67,7 +66,7 @@ class TMState_monitor():
 			module_logger.debug("Old state: "+self.last_state)
 			if self.last_state != currentstate:
 				self.last_state = currentstate
-				self.nexttheme = self.manager.prep_theme_variants(self.state)
+				self.nexttheme = self.manager.prep_theme_variants(self.state, self.theme_styles)
 				self.destop_manager.set_desktop_theme(self.state, self.nexttheme)
 			sleep(60)	# check once in a minute whether the state is changed
 	
@@ -75,6 +74,6 @@ class TMState_monitor():
 		module_logger.info("Starting auto-change at regular interval.")
 		while True:
 			self.state = self.manager.get_state_info()
-			self.nexttheme = self.manager.prep_theme_variants(self.state)
+			self.nexttheme = self.manager.prep_theme_variants(self.state, self.theme_styles)
 			self.destop_manager.set_desktop_theme(self.state, self.nexttheme)
 			sleep(self.manager.theme_interval_in_sec)


### PR DESCRIPTION
- Remove unnecessary modules
- Fix function arguments which lead to no change in theme during startup and when next theme button is clicked at the indicator