### PR TITLE
Add support for libadwaita apps

### DIFF
--- a/src/ThemeManager/DesktopTheme.py
+++ b/src/ThemeManager/DesktopTheme.py
@@ -48,17 +48,19 @@ class desktop_theme():
 			os.system("gsettings set org.cinnamon.desktop.interface gtk-theme %s" % nexttheme[4])
 			# Window border/Metacity
 			os.system("gsettings set org.cinnamon.desktop.wm.preferences theme %s" % nexttheme[5])
+			# Color pref for gtk4 apps
+			os.system("gsettings set org.gnome.desktop.interface color-scheme %s" % nexttheme[6])
 			# Icon theme
 			if self.manager.icon_theme:
-				os.system("gsettings set org.cinnamon.desktop.interface icon-theme %s" % nexttheme[6])
+				os.system("gsettings set org.cinnamon.desktop.interface icon-theme %s" % nexttheme[7])
 			# Cursor theme
 			if self.manager.cursor_theme:
-				os.system("gsettings set org.cinnamon.desktop.interface cursor-theme %s" % nexttheme[7])
+				os.system("gsettings set org.cinnamon.desktop.interface cursor-theme %s" % nexttheme[8])
 			
 			# Plank theme
 			if self.manager.plank_theme:
 				try:
-					os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[8])
+					os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[9])
 				except:
 					module_logger.error("Either 'plank' is not installed or the plank theme is not present.")
 		
@@ -70,17 +72,19 @@ class desktop_theme():
 			os.system("gsettings set org.gnome.desktop.interface gtk-theme %s" % nexttheme[4])
 			# Window border/Metacity
 			os.system("gsettings set org.gnome.desktop.wm.preferences theme %s" % nexttheme[5])
+			# Color pref for gtk4 apps
+			os.system("gsettings set org.gnome.desktop.interface color-scheme %s" % nexttheme[6])
 			# Icon theme
 			if self.manager.icon_theme:
-				os.system("gsettings set org.gnome.desktop.interface icon-theme %s" % nexttheme[6])
+				os.system("gsettings set org.gnome.desktop.interface icon-theme %s" % nexttheme[7])
 			# Cursor theme
 			if self.manager.cursor_theme:
-				os.system("gsettings set org.gnome.desktop.interface cursor-theme %s" % nexttheme[7])
+				os.system("gsettings set org.gnome.desktop.interface cursor-theme %s" % nexttheme[8])
 			
 			# Plank theme
 			if self.manager.plank_theme:
 				try:
-					os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[8])
+					os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[9])
 				except:
 					module_logger.error("Either 'plank' is not installed or the plank theme is not present.")
 		
@@ -90,17 +94,19 @@ class desktop_theme():
 			os.system("gsettings set org.mate.interface gtk-theme %s" % nexttheme[4])
 			# Window border/Metacity
 			os.system("gsettings set org.mate.Marco.general theme %s" % nexttheme[5])
+			# Color pref for gtk4 apps
+			os.system("gsettings set org.gnome.desktop.interface color-scheme %s" % nexttheme[6])
 			# Icon theme
 			if self.manager.icon_theme:
-				os.system("gsettings set org.mate.interface icon-theme %s" % nexttheme[6])
+				os.system("gsettings set org.mate.interface icon-theme %s" % nexttheme[7])
 			# Cursor theme
 			if self.manager.cursor_theme:
-				os.system("gsettings set org.mate.peripherals-mouse cursor-theme %s" % nexttheme[7])
+				os.system("gsettings set org.mate.peripherals-mouse cursor-theme %s" % nexttheme[8])
 			
 			# Plank theme
 			if self.manager.plank_theme:
 				try:
-					os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[8])
+					os.system("gsettings set net.launchpad.plank.dock.settings theme %s" % nexttheme[9])
 				except:
 					module_logger.error("Either 'plank' is not installed or the plank theme is not present")
 			
@@ -108,9 +114,9 @@ class desktop_theme():
 		themes["System"] = nexttheme[4]
 		themes["DE Theme"] = nexttheme[3]
 		themes["Decoration"] = nexttheme[5]
-		themes["Icon"] = nexttheme[6]
-		themes["Cursor"] = nexttheme[7]
-		themes["Plank"] = nexttheme[8]
+		themes["Icon"] = nexttheme[7]
+		themes["Cursor"] = nexttheme[8]
+		themes["Plank"] = nexttheme[9]
 		module_logger.info("Updated with Colour Variant: %s, Themes: %s" % (nexttheme[1], themes))
 	
 	def get_desktop_theme(self, state, systheme, colvariants):

--- a/src/ThemeManager/common.py
+++ b/src/ThemeManager/common.py
@@ -275,6 +275,7 @@ class TMBackend():
 			else:
 				shelltheme = self.systemthemename
 			gtktheme = shelltheme
+			color_pref = "prefer-light"
 		
 		elif currentstate == "night":
 			wmtheme = self.systemthemename+"-"+self.darkmode_suffix
@@ -286,6 +287,7 @@ class TMBackend():
 			else:
 				shelltheme = self.systemthemename+"-"+self.darkmode_suffix
 			gtktheme = shelltheme
+			color_pref = "prefer-dark"
 		
 		else:
 			wmtheme = self.systemthemename+"-"+self.darkmode_suffix
@@ -308,8 +310,10 @@ class TMBackend():
 					gtktheme = self.systemthemename+"-"+self.darkermode_suffix
 				else:
 					gtktheme = self.systemthemename+"-"+self.darkmode_suffix
+			
+			color_pref = "prefer-dark"
 		
-		nxt_theme = [timestamp, currentcolor, stateflag, shelltheme, gtktheme, wmtheme, icontheme, cursrtheme, planktheme]
+		nxt_theme = [timestamp, currentcolor, stateflag, shelltheme, gtktheme, wmtheme, color_pref, icontheme, cursrtheme, planktheme]
 		themes = {}
 		themes["System"] = gtktheme
 		themes["DE Theme"] = shelltheme


### PR DESCRIPTION
- for apps with gtk4 and libadwaita needs gnome color-scheme to be set.
- Uses "prefer-light" during day and "prefer-dark" for transition and night